### PR TITLE
fixed minor issue breaking the CMS when CloudAssets is disabled in YML

### DIFF
--- a/code/CloudFileExtension.php
+++ b/code/CloudFileExtension.php
@@ -262,7 +262,8 @@ class CloudFileExtension extends DataExtension
 	 */
 	public function createLocalIfNeeded() {
 		if ($this->owner->CloudStatus === 'Live') {
-			if ($this->getCloudBucket()->isLocalCopyEnabled()) {
+            $bucket = $this->getCloudBucket();
+            if ($bucket && $bucket->isLocalCopyEnabled()) {
 				if (!file_exists($this->owner->getFullPath()) || $this->containsPlaceholder()) {
 					try {
 						$this->downloadFromCloud();


### PR DESCRIPTION
if cloudassets.yml is set to
CloudAssets:
  disabled: true

$this->getCloudBucket()->isLocalCopyEnabled() throws an error, as getCloudBucket() returns null (line 63 of CloudAssets.php)
