### PR TITLE
Upload Code Coverage to codecov.io 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ matrix:
     - env: DB=MYSQL CORE_RELEASE=3.2
     - env: DB=MYSQL CORE_RELEASE=master
 
+before_install:
+  - pip install --user codecov
+
 before_script:
  - pear -q install --onlyreqdeps pear/PHP_CodeSniffer
  - phpenv rehash
@@ -29,4 +32,12 @@ before_script:
 
 script: ./cloudassets/tests/travis/run_build.sh
 
-after_script: ./cloudassets/test/travis/upload_coverage.sh
+after_script:
+  - pwd
+  - ls -al
+  - find ~ | grep coverage
+  - cp cloudassets/coverage.xml ~/build/$TRAVIS_REPO_SLUG/coverage.xml
+  - cd ~/build/$TRAVIS_REPO_SLUG
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - codecov

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Quality:
 [![Build Status](https://travis-ci.org/markguinn/silverstripe-cloudassets.svg?branch=master)](http://travis-ci.org/markguinn/silverstripe-cloudassets)
 [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/markguinn/silverstripe-cloudassets/badges/quality-score.png?s=506eb40a2197880980ff1f695bde5fe79a4f7442)](https://scrutinizer-ci.com/g/markguinn/silverstripe-cloudassets/)
 [![Code Coverage](https://scrutinizer-ci.com/g/markguinn/silverstripe-cloudassets/badges/coverage.png?s=a2b5c2c4eb1029c5e064271ac764d3c60b374762)](https://scrutinizer-ci.com/g/markguinn/silverstripe-cloudassets/)
+[![codecov.io](https://codecov.io/github/markguinn/silverstripe-cloudassets/coverage.svg?branch=master)](https://codecov.io/github/markguinn/silverstripe-cloudassets?branch=master)
+
+![codecov.io](https://codecov.io/github/markguinn/silverstripe-cloudassets/branch.svg?branch=master)
 
 Support:
 [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/markguinn/silverstripe-cloudassets?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)

--- a/tests/travis/upload_coverage.sh
+++ b/tests/travis/upload_coverage.sh
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-set -e
-if [ -n "$COVERAGE" ]; then
-	cd cloudassets
-	wget https://scrutinizer-ci.com/ocular.phar
-	php ocular.phar code-coverage:upload -v --format=php-clover coverage.xml
-fi


### PR DESCRIPTION
HI Mark

This pull request adds upload of the clover coverage file to codecov.io, and relevant extra info in the README file in the form of a badge for coverage percentage and a graph of the coverage for the last 20 commits.

An example coverage report can be seen here, https://codecov.io/github/gordonbanderson/silverstripe-cloudassets/code?ref=5ea9ae0dbd7d7ab141f77aa1e9c85b3771cb00a0

Regards

Gordon