### PR TITLE
Clear the stat cache on converting to placeholder

### DIFF
--- a/code/CloudFileExtension.php
+++ b/code/CloudFileExtension.php
@@ -210,6 +210,7 @@ class CloudFileExtension extends DataExtension
             CloudAssets::inst()->getLogger()->debug("CloudAssets: converting $path to placeholder");
             Filesystem::makeFolder(dirname($path));
             file_put_contents($path, Config::inst()->get('CloudAssets', 'file_placeholder'));
+            clearstatcache();
         }
 
         return $this->owner;


### PR DESCRIPTION
In certain situations, it's possible for the `containsPlaceholder` call to be
called before and after `convertToPlaceholder`. This leads to PHP returning the
cached file size in the second call, incorrectly causing `convertToPlaceholder`
to return `false.