### PR TITLE
Update for SS3.7x and PHP7.2

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,0 +1,1 @@
+if (!class_exists('SS_Object')) class_alias('Object', 'SS_Object');

--- a/_config.php
+++ b/_config.php
@@ -1,1 +1,3 @@
+<?php
+
 if (!class_exists('SS_Object')) class_alias('Object', 'SS_Object');

--- a/code/CloudAssets.php
+++ b/code/CloudAssets.php
@@ -6,7 +6,7 @@
  * @date 01.10.2014
  * @package cloudassets
  */
-class CloudAssets extends Object
+class CloudAssets extends SS_Object
 {
     /** @var bool - kill switch via config - if true the module will ignore all cloud buckets */
     private static $disabled = false;

--- a/code/CloudBucket.php
+++ b/code/CloudBucket.php
@@ -6,7 +6,7 @@
  * @date 01.10.2014
  * @package cloudassets
  */
-abstract class CloudBucket extends Object
+abstract class CloudBucket extends SS_Object
 {
     const BASE_URL   = 'BaseURL';
     const SECURE_URL = 'SecureURL';


### PR DESCRIPTION
With the release of SS3.7x adding PHP7.2 they have migrated the reserved Object keyword to SS_Object.  This commit resolves any conflicts based off of their documentation.  https://docs.silverstripe.org/en/3/changelogs/3.7.0/